### PR TITLE
Update Audi Q4 e-tron: Correct model year and add Wikipedia references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,6 @@
 
 This repository contains signal set configurations for the Audi Q4 e-tron, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Audi Q4 e-tron.
 
-## Generations
-
-The Audi Q4 e-tron has been through one generation since its introduction:
-
-- **First Generation (2021-present)**: The Audi Q4 e-tron was introduced as Audi's compact electric SUV, built on the Volkswagen Group's MEB platform dedicated to electric vehicles. The concept was unveiled in 2019, with production beginning in March 2021 and the production version officially unveiled in April 2021. Available in standard SUV and Sportback body styles, it features either rear-wheel drive or quattro all-wheel drive options. The Q4 e-tron offers various battery and power output configurations, with the rear-wheel-drive Q4 45 e-tron model providing up to 288 miles of EPA-rated range, while the all-wheel-drive Q4 e-tron 55 models offer up to 258 miles. The interior showcases Audi's digital cockpit with optional augmented reality head-up display technology that provides real-time vehicle information in the driver's line of sight. The vehicle features a drag coefficient of 0.26 in the Sportback version and 0.28 for the standard SUV model, with boot space of 520 L (535 L for Sportback) expandable to 1,490 L (1,460 L for Sportback) with rear seats folded. The Q4 e-tron received a significant update for the 2024 model year, bringing more power, longer range, and an updated suspension.
-
 ## Contributing
 
 Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,5 +1,8 @@
+references:
+  - "https://en.wikipedia.org/wiki/Audi_Q4_e-tron"
+
 generations:
   - name: "First Generation"
-    start_year: 2021
+    start_year: 2022
     end_year: null
     description: "The Audi Q4 e-tron is the brand's first compact electric SUV, built on the Volkswagen Group MEB platform dedicated to electric vehicles. It's available in both standard SUV and Sportback body styles with the latter featuring a more coupe-like roofline. The Q4 e-tron is offered with various powertrain configurations, including single-motor rear-wheel drive (Q4 40 e-tron) producing 201 HP and dual-motor quattro all-wheel drive (Q4 50 e-tron) delivering 295 HP. Battery options include 52 kWh and 77 kWh (net capacity) packs, with the larger battery providing up to 320 miles of range (WLTP). The interior features Audi's latest technology including an available augmented reality head-up display that projects navigation instructions into the driver's field of view. The Q4 e-tron brings Audi's premium electric vehicle experience to a more accessible price point while maintaining the brand's design, quality, and technology standards."


### PR DESCRIPTION
- Fixed: Start year corrected from 2021 to 2022 per Wikipedia model_years
- Added: Wikipedia reference to generations.yaml
- Updated: README.md to standard template

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
