### PR TITLE
Update Audi Q4 e-tron generations: correct start year to 2021

### DIFF
--- a/generations.yaml
+++ b/generations.yaml
@@ -3,6 +3,6 @@ references:
 
 generations:
   - name: "First Generation"
-    start_year: 2022
+    start_year: 2021
     end_year: null
     description: "The Audi Q4 e-tron is the brand's first compact electric SUV, built on the Volkswagen Group MEB platform dedicated to electric vehicles. It's available in both standard SUV and Sportback body styles with the latter featuring a more coupe-like roofline. The Q4 e-tron is offered with various powertrain configurations, including single-motor rear-wheel drive (Q4 40 e-tron) producing 201 HP and dual-motor quattro all-wheel drive (Q4 50 e-tron) delivering 295 HP. Battery options include 52 kWh and 77 kWh (net capacity) packs, with the larger battery providing up to 320 miles of range (WLTP). The interior features Audi's latest technology including an available augmented reality head-up display that projects navigation instructions into the driver's field of view. The Q4 e-tron brings Audi's premium electric vehicle experience to a more accessible price point while maintaining the brand's design, quality, and technology standards."


### PR DESCRIPTION
- Updated start_year from 2022 to 2021 to reflect actual production commencement
- Production began in March 2021 according to Wikipedia
- Consumer market launch was 2022 model year
- Reference: https://en.wikipedia.org/wiki/Audi_Q4_e-tron

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
